### PR TITLE
Allow to run a specific command (somewhat i3blocks compatible)

### DIFF
--- a/cmd/goi3bar/goi3bar.go
+++ b/cmd/goi3bar/goi3bar.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/denbeigh2000/goi3bar/packages/disk"
 	_ "github.com/denbeigh2000/goi3bar/packages/memory"
 	_ "github.com/denbeigh2000/goi3bar/packages/network"
+	_ "github.com/denbeigh2000/goi3bar/packages/command"
 
 	"flag"
 	"fmt"

--- a/packages/command/command.go
+++ b/packages/command/command.go
@@ -1,0 +1,56 @@
+package command
+
+import (
+	i3 "github.com/denbeigh2000/goi3bar"
+	"os/exec"
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+)
+
+type CommandItem struct {
+}
+
+type CommandGenerator struct {
+	Label    string `json:"label"`
+	Instance string `json:"instance"`
+	Command  string `json:"command"`
+	Color    string `json:"color"`
+
+	// Identifier for receiving click events
+	Name     string
+}
+
+func (g CommandGenerator) Generate() ([]i3.Output, error) {
+	items := make([]i3.Output, 1)
+
+	items[0].Name = g.Name
+	cmd := exec.Command(g.Command)
+	if (len(g.Instance) > 0) {
+		cmd.Env = []string{fmt.Sprintf("BLOCK_INSTANCE=%s", g.Instance)}
+	}
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		log.Panicf("Failed to execute %s: %v", g.Command, err)
+		items[0].FullText = "ERROR"
+		items[0].Color = i3.DefaultColors.Crit
+	} else {
+		if (g.Color == "") {
+			items[0].Color = i3.DefaultColors.General
+		} else {
+			items[0].Color = g.Color
+		}
+		text := strings.TrimRight(out.String(), "\n\r")
+		if (g.Label == "") {
+			items[0].FullText = fmt.Sprintf("%s %s", g.Label, text)
+		} else {
+			items[0].FullText = text
+		}
+	}
+	items[0].Instance = g.Command
+	items[0].Separator = true
+	return items, nil
+}

--- a/packages/command/commandbuilder.go
+++ b/packages/command/commandbuilder.go
@@ -1,0 +1,42 @@
+package command
+
+import (
+	i3 "github.com/denbeigh2000/goi3bar"
+	"github.com/denbeigh2000/goi3bar/config"
+	"time"
+)
+
+const Identifier = "command"
+
+type CommandConfig struct {
+	Interval string             `json:"interval"`
+	Options  CommandGenerator   `json:"options"`
+}
+
+type CommandBuilder struct {
+}
+
+func (b CommandBuilder) Build(c config.Config) (p i3.Producer, err error) {
+	conf := CommandConfig{}
+	err = c.ParseConfig(&conf)
+	if err != nil {
+		return
+	}
+
+	interval, err := time.ParseDuration(conf.Interval)
+	if err != nil {
+		return
+	}
+
+	conf.Options.Name = Identifier
+
+	return &i3.BaseProducer{
+		Generator: conf.Options,
+		Interval:  interval,
+		Name:      "cmd",
+	}, nil
+}
+
+func init() {
+	config.Register("command", CommandBuilder{})
+}


### PR DESCRIPTION
Support i3blocks style commands, example configuration snippet:

```
    {
        "package": "command",
        "name": "Audio",
        "options": {
            "interval": "5s",
            "options": {
                "label": "VOL",
                "command": "/usr/libexec/i3blocks/volume"
            }
        }
    },
```

Another options are `color` and `instance`. Color meaning is obvious, and instance is something that gets passed to command through the `BLOCK_INSTANCE` environment value. I.e. `"instance": "eth0"`, `"instance": "Master"`, or `"instance": "/dev/sda1"` - whatever is most suitable for the command.
